### PR TITLE
docs: notes: Fix typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,6 @@ Contents:
    notes/cpp_template
    notes/cpp_constexpr
    notes/cpp_lambda
-   notes/cpp_smartpoints
+   notes/cpp_smartpointers
    notes/cpp_forwarding
    notes/gdb_debug

--- a/docs/notes/cpp_smartpointers.rst
+++ b/docs/notes/cpp_smartpointers.rst
@@ -1,6 +1,6 @@
-============
-Smart Points
-============
+==============
+Smart Pointers
+==============
 
 Custom Deleters
 ---------------


### PR DESCRIPTION
1. Renamed `docs/notes/cpp_smartpoints.rst` to `docs/notes/cpp_smartpointers.rst`
2. Replaced `Smart Points` with `Smart Pointers`.

Thank you!

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>